### PR TITLE
Add gopher url

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -264,6 +264,10 @@
         "issue_mail": {
           "description": "A separate email address for issue reports (see the <em>issue_report_channels</em> field). This value can be Base64-encoded.",
           "type": "string"
+        },
+        "gopher": {
+          "description": "A url to find information about the Space in the Gopherspace.",
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
As Gopher is a fast-growing emerging technology, I find it important that a space can also show his representation in the gopher space on the space API