### PR TITLE
Add gopher URL

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -274,7 +274,8 @@
           "type": "string"
         },
         "gopher": {
-          "description": "A URL to find information about the Space in the Gopherspace. Example: gopher://gopher.binary-kitchen.de"
+          "description": "A URL to find information about the Space in the Gopherspace. Example: gopher://gopher.binary-kitchen.de",
+          "type": "string"
         }
       }
     },

--- a/14-draft.json
+++ b/14-draft.json
@@ -272,6 +272,9 @@
         "issue_mail": {
           "description": "A separate email address for issue reports (see the <em>issue_report_channels</em> field). This value can be Base64-encoded.",
           "type": "string"
+        },
+        "gopher": {
+          "description": "A URL to find information about the Space in the Gopherspace. Example: gopher://gopher.binary-kitchen.de"
         }
       }
     },


### PR DESCRIPTION
As Gopher is a fast-growing emerging technology, I find it important that a space can also show his representation in the gopher space on the space API. Now with example and fixed spelling :)