### PR TITLE
Add nextchange field

### DIFF
--- a/endpoint/14-draft.json
+++ b/endpoint/14-draft.json
@@ -112,6 +112,10 @@
           "description": "The Unix timestamp when the space status changed most recently",
           "type": "number"
         },
+        "nextchange": {
+          "description": "The Unix timestamp of the estimated next change (eg. planned event start/end)",
+          "type": "number"
+        },
         "trigger_person": {
           "description": "The person who lastly changed the state e.g. opened or closed the space.",
           "type": "string"


### PR DESCRIPTION
Adds an optional `nextchange` field, indicating when the open/closed state might change in the near future. Could be used to indicate when it will close so people don't start the commute only to encounter closed doors.