### PR TITLE
Remove Google+

### DIFF
--- a/endpoint/14-draft.json
+++ b/endpoint/14-draft.json
@@ -239,16 +239,6 @@
           "description": "Facebook account URL.",
           "type": "string"
         },
-        "google": {
-          "description": "Google services.",
-          "type": "object",
-          "properties": {
-            "plus": {
-              "description": "Google plus URL.",
-              "type": "string"
-            }
-          }
-        },
         "identica": {
           "description": "Identi.ca or StatusNet account, in the form <samp>yourspace@example.org</samp>",
           "type": "string"


### PR DESCRIPTION
Since Google+ will be shut down in April of 2019, there's no need to keep it in the API. See https://www.theverge.com/2018/12/10/18134541/google-plus-privacy-api-data-leak-developers