### PR TITLE
Remove cache key

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -1067,32 +1067,6 @@
         }
       }
     },
-    "cache": {
-      "description": "Specifies options about caching of your SpaceAPI endpoint. Use this if you want to avoid hundreds/thousands of application instances crawling your status.",
-      "type": "object",
-      "properties": {
-        "schedule": {
-          "description": "Cache update cycle. This field must match the basic regular expression <code>^[mhd]\\.[0-9]{2}$</code>, where the first field specifies a unit of time (<code>m</code> for 1 minute, <code>h</code> for 1 hour, <code>d</code> for 1 day), and the second field specifies how many of this unit should be skipped between updates. For example, <samp>m.10</samp> means one updates every 10 minutes, <samp>h.03</samp> means one update every 3 hours, and <samp>d.01</samp> means one update every day.",
-          "type": "string",
-          "enum": [
-            "m.02",
-            "m.05",
-            "m.10",
-            "m.15",
-            "m.30",
-            "h.01",
-            "h.02",
-            "h.04",
-            "h.08",
-            "h.12",
-            "d.01"
-          ]
-        }
-      },
-      "required": [
-        "schedule"
-      ]
-    },
     "projects": {
       "description": "Your project sites (links to GitHub, wikis or wherever your projects are hosted)",
       "type": "array",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,4 @@ Changes should start with one of the following tags:
 - [added] The `mastodon` key was added under `contact` and to `contact.keymasters` array items
 - [changed] The description of `location.lon` was changed to state the correct direction.
 - [changed] The keys `state` and `state.open` are not required anymore and `state.open` is no longer nullable.
-- [removed] The cache key was removed
+- [removed] The `cache` key was removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ Changes should start with one of the following tags:
 - [added] The `mastodon` key was added under `contact` and to `contact.keymasters` array items
 - [changed] The description of `location.lon` was changed to state the correct direction.
 - [changed] The keys `state` and `state.open` are not required anymore and `state.open` is no longer nullable.
+- [removed] The cache key was removed


### PR DESCRIPTION
The cache key is not used right now and the same function can already be achieved by using http header (e.g. [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control))