### PR TITLE
Removes issue report channel

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -264,7 +264,7 @@
           "type": "string"
         },
         "issue_mail": {
-          "description": "A separate email address for issue reports (see the <em>issue_report_channels</em> field). This value can be Base64-encoded.",
+          "description": "A separate email address for issue reports. This value can be Base64-encoded.",
           "type": "string"
         },
         "gopher": {
@@ -272,20 +272,6 @@
           "type": "string"
         }
       }
-    },
-    "issue_report_channels": {
-      "description": "This array defines all communication channels where you want to get automated issue reports about your SpaceAPI endpoint from the revalidator. This field is meant for internal usage only and it should never be consumed by any app. At least one channel must be defined. Please consider that when using <samp>ml</samp> the mailing list moderator has to moderate incoming emails or add the sender email to the subscribers. If you don't break your SpaceAPI implementation you won't get any notifications ;-)",
-      "type": "array",
-      "items": {
-        "type": "string",
-        "enum": [
-          "email",
-          "issue_mail",
-          "twitter",
-          "ml"
-        ]
-      },
-      "minItems": 1
     },
     "sensors": {
       "description": "Data of various sensors in your space (e.g. temperature, humidity, amount of Club-Mate left, \u2026). The only canonical property is the <em>temp</em> property, additional sensor types may be defined by you. In this case, you are requested to share your definition for inclusion in this specification.",
@@ -1190,7 +1176,6 @@
     "logo",
     "url",
     "location",
-    "contact",
-    "issue_report_channels"
+    "contact"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ Changes should start with one of the following tags:
 - [added] The `mastodon` key was added under `contact` and to `contact.keymasters` array items
 - [changed] The description of `location.lon` was changed to state the correct direction.
 - [changed] The keys `state` and `state.open` are not required anymore and `state.open` is no longer nullable.
+- [removed] The `issue_report_channel` key was removed


### PR DESCRIPTION
Right now the issue_report_channel is a bit weird:
E.g.
```json
{
  "contact": {
    "email": "foo@example.com"
  },
  "issue_report_channel": [
    "issue_email",
    "twitter"
  ]
}
```
Which would be valid but obviously doesn't make any sense.

I would remove it since we don't use it anyways.