### PR TITLE
Use union merge for CHANGELOG

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Avoids merge conflicts due to multiple additions to the CHANGELOG.