### PR TITLE
Replace api field with api_compatibility

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -4,8 +4,8 @@
   "description": "SpaceAPI 0.14",
   "type": "object",
   "properties": {
-    "api": {
-      "description": "The version of SpaceAPI your endpoint uses",
+    "version_compatibility": {
+      "description": "The versions your SpaceAPI endpoint supports",
       "type": "array",
       "items": {
         "type": "string"
@@ -1107,7 +1107,7 @@
     }
   },
   "required": [
-    "api",
+    "version_compatibility",
     "space",
     "logo",
     "url",

--- a/14-draft.json
+++ b/14-draft.json
@@ -4,7 +4,7 @@
   "description": "SpaceAPI 0.14",
   "type": "object",
   "properties": {
-    "version_compatibility": {
+    "api_compatibility": {
       "description": "The versions your SpaceAPI endpoint supports",
       "type": "array",
       "items": {
@@ -1107,7 +1107,7 @@
     }
   },
   "required": [
-    "version_compatibility",
+    "api_compatibility",
     "space",
     "logo",
     "url",

--- a/14-draft.json
+++ b/14-draft.json
@@ -6,10 +6,13 @@
   "properties": {
     "api": {
       "description": "The version of SpaceAPI your endpoint uses",
-      "type": "string",
-      "enum": [
-        "0.14"
-      ]
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "0.14"
+      }
     },
     "space": {
       "description": "The name of your space",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ Changes should start with one of the following tags:
 - [removed] The `issue_report_channel` key was removed
 - [removed] The `cache` key was removed
 - [removed] The `radio_show` key was removed
+- [changed] `api` field is now an array that should contain the version as a string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@ Changes should start with one of the following tags:
 - [removed] The `issue_report_channel` key was removed
 - [removed] The `cache` key was removed
 - [removed] The `radio_show` key was removed
-- [changed] `api` field is now an array that should contain the version as a string
+- [removed] The `api` key was removed
+- [added] The `version_compatibility` field was added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,4 @@ Changes should start with one of the following tags:
 - [removed] The `cache` key was removed
 - [removed] The `radio_show` key was removed
 - [removed] The `api` key was removed
-- [added] The `version_compatibility` field was added
+- [added] The `api_compatibility` field was added


### PR DESCRIPTION
This way you can build a spaceapi file that is compatible to multiple versions to make a soft migration to new versions possible.

At least as long you don't need to use fields that exclude each other (e.g. using `hPA` barometer unit in 0.13 vs. `hPa` in 0.14).

Renamed the field so it won't be incompatible to versions 0.13 and lower.

Not sure if the field should still be required, but that's something we can also discuss later.

