### PR TITLE
Add "network traffic" sensor type

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -995,7 +995,7 @@
                         "minimum": 0
                       },
                       "maximum": {
-                        "description": "The maximum available bandwith in bits/second, e.g. as sold by your ISP",
+                        "description": "The maximum available throughput in bits/second, e.g. as sold by your ISP",
                         "type": "number",
                         "minimum": 0
                       }

--- a/14-draft.json
+++ b/14-draft.json
@@ -977,29 +977,25 @@
           }
         },
         "network_traffic": {
-          "description": "The current network bandwidth usage",
+          "description": "The current network traffic, in bits/second or packets/second (or both)",
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
-              "value": {
-                "description": "The measurement value",
-                "type": "number"
+              "bits_per_second": {
+                "description": "The bits per second measurement value",
+                "type": "number",
+                "minimum": 0
               },
-              "unit": {
-                "description": "The measurement unit",
-                "type": "string",
-                "enum": [
-                  "packets/s",
-                  "bit/s",
-                  "kbit/s",
-                  "Mbit/s",
-                  "Gbit/s",
-                  "Byte/s",
-                  "kByte/s",
-                  "MByte/s",
-                  "GByte/s"
-                ]
+              "packets_per_second": {
+                "description": "The packets per second measurement value",
+                "type": "number",
+                "minimum": 0
+              },
+              "max_bits_per_second": {
+                "description": "The maximum available bandwith in bits/second, e.g. as sold by your ISP",
+                "type": "number",
+                "minimum": 0
               },
               "name": {
                 "description": "Name of the measurement, e.g. to distinguish between upstream and downstream traffic",
@@ -1009,11 +1005,7 @@
                 "description": "Location the measurement relates to, e.g. <samp>WiFi</samp> or <samp>Uplink</samp>.",
                 "type": "string"
               }
-            },
-            "required": [
-              "value",
-              "unit"
-            ]
+            }
           },
           "minItems": 1
         }

--- a/14-draft.json
+++ b/14-draft.json
@@ -1018,10 +1018,7 @@
                       "value"
                     ]
                   }
-                },
-                "required": [
-                  "properties"
-                ]
+                }
               },
               "name": {
                 "description": "Name of the measurement, e.g. to distinguish between upstream and downstream traffic",
@@ -1035,7 +1032,10 @@
                 "description": "An extra field that you can use to attach some additional information to this sensor instance",
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "properties"
+            ]
           },
           "minItems": 1
         }

--- a/14-draft.json
+++ b/14-draft.json
@@ -975,6 +975,47 @@
               "value"
             ]
           }
+        },
+        "network_traffic": {
+          "description": "The current network bandwidth usage",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "description": "The measurement value",
+                "type": "number"
+              },
+              "unit": {
+                "description": "The measurement unit",
+                "type": "string",
+                "enum": [
+                  "packets/s",
+                  "bit/s",
+                  "kbit/s",
+                  "Mbit/s",
+                  "Gbit/s",
+                  "Byte/s",
+                  "kByte/s",
+                  "MByte/s",
+                  "GByte/s"
+                ]
+              },
+              "name": {
+                "description": "Name of the measurement, e.g. to distinguish between upstream and downstream traffic",
+                "type": "string"
+              },
+              "location": {
+                "description": "Location the measurement relates to, e.g. <samp>WiFi</samp> or <samp>Uplink</samp>.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "value",
+              "unit"
+            ]
+          },
+          "minItems": 1
         }
       }
     },

--- a/14-draft.json
+++ b/14-draft.json
@@ -982,27 +982,57 @@
           "items": {
             "type": "object",
             "properties": {
-              "bits_per_second": {
-                "description": "The bits per second measurement value",
-                "type": "number",
-                "minimum": 0
-              },
-              "packets_per_second": {
-                "description": "The packets per second measurement value",
-                "type": "number",
-                "minimum": 0
-              },
-              "max_bits_per_second": {
-                "description": "The maximum available bandwith in bits/second, e.g. as sold by your ISP",
-                "type": "number",
-                "minimum": 0
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "bits_per_second": {
+                    "description": "",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value, in bits/second",
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "maximum": {
+                        "description": "The maximum available bandwith in bits/second, e.g. as sold by your ISP",
+                        "type": "number",
+                        "minimum": 0
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  },
+                  "packets_per_second": {
+                    "description": "",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value, in packets/second",
+                        "type": "number",
+                        "minimum": 0
+                      }
+                    },
+                    "required": [
+                      "value"
+                    ]
+                  }
+                },
+                "required": [
+                  "properties"
+                ]
               },
               "name": {
                 "description": "Name of the measurement, e.g. to distinguish between upstream and downstream traffic",
                 "type": "string"
               },
               "location": {
-                "description": "Location the measurement relates to, e.g. <samp>WiFi</samp> or <samp>Uplink</samp>.",
+                "description": "Location the measurement relates to, e.g. <samp>WiFi</samp> or <samp>Uplink</samp>",
+                "type": "string"
+              },
+              "description": {
+                "description": "An extra field that you can use to attach some additional information to this sensor instance",
                 "type": "string"
               }
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ Changes should start with one of the following tags:
 - [removed] The `issue_report_channel` key was removed
 - [removed] The `cache` key was removed
 - [removed] The `radio_show` key was removed
+- [added] The `network_traffic` sensor was added


### PR DESCRIPTION
This PR adds a new sensor type, `network_traffic`, which enables the sharing of network traffic statistics other than the already present number of active connections.