### PR TITLE
Add "links" section to v14 schema

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -1125,6 +1125,31 @@
         "type": "string"
       }
     },
+    "links": {
+      "description": "Arbitrary links that you'd like to share",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The link name.",
+            "type": "string"
+          },
+          "description": {
+            "description": "An extra field for a more detailed description of the link.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL.",
+            "type": "string"
+          }
+        },
+        "required": [
+            "name",
+            "url"
+        ]
+      }
+    },
     "membership_plans": {
       "description": "A list of the different membership plans your hackerspace might have. Set the value according to your billing process. For example, if your membership fee is 10€ per month, but you bill it yearly (aka. the member pays the fee once per year), set the amount to 120 an the billing_interval to yearly.",
       "type": "array",

--- a/14-draft.json
+++ b/14-draft.json
@@ -1145,8 +1145,8 @@
           }
         },
         "required": [
-            "name",
-            "url"
+          "name",
+          "url"
         ]
       }
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ Changes should start with one of the following tags:
 - [removed] The `api` key was removed
 - [added] The `api_compatibility` field was added
 - [added] The `network_traffic` sensor was added
+- [added] The `links` section was added


### PR DESCRIPTION
In order to cover some use cases that we haven't yet anticipated, it would be great to have a generic "links" section in the schema (as already suggested by @rnestler in #30).

Suggestion:

```json
{
  …
  "links": [
    {
      "name": "Door Twitter",
      "description": "The Twitter account which tweets our door open status",
      "url": "https://twitter.com/foo/bar"
    },
    {
      "name": "Jitsi",
      "description": "Our Jitsi instance, public for everybody!",
      "url": "https://jitsi.example.org/"
    }
  ]
}
```

The `name` and `url` fields would be required, `description` is optional.