### PR TITLE
Add the area_size key

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -45,6 +45,10 @@
         "timezone": {
           "description": "The timezone the space is located in. It should be formatted according to the <a target=\"_blank\" href=\"https://en.wikipedia.org/wiki/List_of_tz_database_time_zones\">TZ database location names</a>.",
           "type": "string"
+        },
+        "area_size": {
+          "description": "The total size of your space in square meters",
+          "type": "number"
         }
       },
       "required": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@ Changes should start with one of the following tags:
 - [removed] The `api` key was removed
 - [added] The `api_compatibility` field was added
 - [added] The `network_traffic` sensor was added
+- [added] The `area_size` key was added under `location`


### PR DESCRIPTION
I just realized that one of the, for me, very interesting information is missing.
It gives me a rough estimate what to expect before i visit a space (e.g. a room in a cellar or the 4000 m2 mega monster space).