### PR TITLE
Barometer sensor: Soft-remove `hPA` unit for compatibility reasons

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -345,10 +345,11 @@
                 "type": "number"
               },
               "unit": {
-                "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                "description": "The unit of pressure used by your sensor<br>Note: The <code>hPA</code> unit is deprecated and should not be used anymore. Use the correct <code>hPa</code> unit instead.",
                 "type": "string",
                 "enum": [
-                  "hPa"
+                  "hPa",
+                  "hPA"
                 ]
               },
               "location": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes should start with one of the following tags:
 - [changed] The value in `sensors.account_balance` can now be any ISO 4217 string
 - [added] The `timezone` key was added under `location`
 - [added] The `membership_plans` key was added to represent membership plans a space might have
-- [changed] The unit `hPA` in `sensors.barometer.unit` was renamed to `hPa` to match the SI unit
+- [changed] The unit `hPA` in `sensors.barometer.unit` was deprecated, use `hPa` instead to match the SI unit
 - [added] The `mastodon` key was added under `contact` and to `contact.keymasters` array items
 - [changed] The description of `location.lon` was changed to state the correct direction.
 - [removed] The `google` key was removed from `contact`


### PR DESCRIPTION
This way, an endpoint with a barometer sensor can be compatible with
both 0.13 and 0.14. See discussion in #69.