### PR TITLE
Add linked_spaces attribute

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -1174,6 +1174,22 @@
           "billing_interval"
         ]
       }
+    },
+    "linked_spaces": {
+      "description": "A list of spaces you know and feel connected too.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "description": "The space's website according to their SpaceAPI endpoint",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
     }
   },
   "required": [


### PR DESCRIPTION
I would go with the spaces website, I've named it according to the SpaceAPI field.

Discussion can be found in [issue 144](https://github.com/SpaceApi/directory/issues/144) and in the [meeting notes](https://github.com/SpaceApi/meeting-notes/blob/master/20200510-telco.md#5-decentralized-directory)

