### PR TITLE
Add "mumble" contact option

### DIFF
--- a/14-draft.json
+++ b/14-draft.json
@@ -254,6 +254,10 @@
         "matrix": {
           "description": "Matrix channel/community for the Hackerspace. Example: <samp>#spaceroom:example.org</samp> or <samp>+spacecommunity:example.org</samp>",
           "type": "string"
+        },
+        "mumble": {
+          "description": "URL to a Mumble server/channel, as specified in <a href=\"https://wiki.mumble.info/wiki/Mumble_URL\" target=\"_blank\">Mumble URL</a>. Example: <samp>mumble://mumble.example.org/spaceroom?version=1.2.0</samp>",
+          "type": "string"
         }
       }
     },

--- a/14-draft.json
+++ b/14-draft.json
@@ -256,7 +256,7 @@
           "type": "string"
         },
         "mumble": {
-          "description": "URL to a Mumble server/channel, as specified in <a href=\"https://wiki.mumble.info/wiki/Mumble_URL\" target=\"_blank\">Mumble URL</a>. Example: <samp>mumble://mumble.example.org/spaceroom?version=1.2.0</samp>",
+          "description": "URL to a Mumble server/channel, as specified in https://wiki.mumble.info/wiki/Mumble_URL . Example: <samp>mumble://mumble.example.org/spaceroom?version=1.2.0</samp>",
           "type": "string"
         }
       }


### PR DESCRIPTION
Mumble specifies its own [`mumble:` URL scheme](https://wiki.mumble.info/wiki/Mumble_URL), and Mumble is used by a lot of spaces, so I think we should add support for this.