### PR TITLE
Add endpoind field to linked_spaces, rename url field to website

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -1181,13 +1181,16 @@
       "items": {
         "type": "object",
         "properties": {
+          "endpoint": {
+            "description": "The SpaceAPI endpoint of the space",
+            "type": "string"
+          },
           "url": {
-            "description": "The space's website according to their SpaceAPI endpoint",
+            "description": "The website of the space",
             "type": "string"
           }
         },
         "required": [
-          "url"
         ]
       }
     }

--- a/15-draft.json
+++ b/15-draft.json
@@ -1185,7 +1185,7 @@
             "description": "The SpaceAPI endpoint of the space",
             "type": "string"
           },
-          "url": {
+          "website": {
             "description": "The website of the space",
             "type": "string"
           }

--- a/15-draft.json
+++ b/15-draft.json
@@ -1190,14 +1190,17 @@
             "type": "string"
           }
         },
-        
         "anyOf": [
-          "required": [
-            "endpoint"
-          ],
-          "required": [
-            "website"
-          ]
+          {
+            "required": [
+              "endpoint"
+            ]
+          },
+          {
+            "required": [
+              "website"
+            ]
+          }
         ]
       }
     }

--- a/15-draft.json
+++ b/15-draft.json
@@ -1190,7 +1190,14 @@
             "type": "string"
           }
         },
-        "required": [
+        
+        "anyOf": [
+          "required": [
+            "endpoint"
+          ],
+          "required": [
+            "website"
+          ]
         ]
       }
     }


### PR DESCRIPTION
By adding a field to specify the SpaceAPI endpoints of other spaces self discovery of the spaces in the SpaceAPI network becomes possible. This change would eventually allow for a SpaceAPI that is functional without the central directory.

If the endpoint field is filled out then the URL field of the linked space should be left absent as the url can instead be read from the spaces own SpaceAPI endpoint. Because of this I've made the URL endpoint optional.