### PR TITLE
Added lastchange property to all sensors. Fixes #95

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -297,7 +297,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -331,7 +331,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -372,7 +372,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -429,7 +429,7 @@
                     "type": "string"
                   },
                   "lastchange": {
-                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                     "type": "number"
                   }
                 },
@@ -481,7 +481,7 @@
                     "type": "string"
                   },
                   "lastchange": {
-                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                     "type": "number"
                   }
                 },
@@ -533,7 +533,7 @@
                     "type": "string"
                   },
                   "lastchange": {
-                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                     "type": "number"
                   }
                 },
@@ -585,7 +585,7 @@
                     "type": "string"
                   },
                   "lastchange": {
-                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                     "type": "number"
                   }
                 },
@@ -627,7 +627,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -669,7 +669,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -711,7 +711,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -841,7 +841,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -903,7 +903,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -939,7 +939,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -972,7 +972,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -1012,7 +1012,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },
@@ -1078,7 +1078,7 @@
                 "type": "string"
               },
               "lastchange": {
-                "description": "The Unix timestamp when the sensor value changed most recently",
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently.",
                 "type": "number"
               }
             },

--- a/15-draft.json
+++ b/15-draft.json
@@ -295,6 +295,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -325,6 +329,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -362,6 +370,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -415,6 +427,10 @@
                   "description": {
                     "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                     "type": "string"
+                  },
+                  "lastchange": {
+                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -463,6 +479,10 @@
                   "description": {
                     "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                     "type": "string"
+                  },
+                  "lastchange": {
+                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -511,6 +531,10 @@
                   "description": {
                     "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                     "type": "string"
+                  },
+                  "lastchange": {
+                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -559,6 +583,10 @@
                   "description": {
                     "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                     "type": "string"
+                  },
+                  "lastchange": {
+                    "description": "The Unix timestamp when the sensor value changed most recently",
+                    "type": "number"
                   }
                 },
                 "required": [
@@ -597,6 +625,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -635,6 +667,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -673,6 +709,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -799,6 +839,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -857,6 +901,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -889,6 +937,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -918,6 +970,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -954,6 +1010,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance.",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [
@@ -1016,6 +1076,10 @@
               "description": {
                 "description": "An extra field that you can use to attach some additional information to this sensor instance",
                 "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp when the sensor value changed most recently",
+                "type": "number"
               }
             },
             "required": [


### PR DESCRIPTION
The lastchange property represents a unix timestamp indicating the time
the sensor value was last updated.

For the wind sensor, I added it at the top object, but it could also be added to the nested object properties.