### PR TITLE
Specify that the Unix timestamp is in seconds

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -87,7 +87,7 @@
           "type": "boolean"
         },
         "lastchange": {
-          "description": "The Unix timestamp when the space status changed most recently",
+          "description": "The Unix timestamp (in seconds) when the space status changed most recently.",
           "type": "number"
         },
         "trigger_person": {
@@ -138,7 +138,7 @@
             "type": "string"
           },
           "timestamp": {
-            "description": "Unix timestamp when the event occurred",
+            "description": "The Unix timestamp (in seconds) when the event occurred.",
             "type": "number"
           },
           "extra": {


### PR DESCRIPTION
This applies to `state.lastchange` and `events.timestamp`.

As asked in #97 