### PR TITLE
Add power_generation sensor

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -827,7 +827,7 @@
                 "type": "number"
               },
               "unit": {
-                "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                "description": "The unit of the sensor value.",
                 "type": "string",
                 "enum": [
                   "mW",

--- a/15-draft.json
+++ b/15-draft.json
@@ -816,6 +816,53 @@
             ]
           }
         },
+        "power_generation": {
+          "description": "The power generation of a specific device or of your whole space",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "description": "The sensor value",
+                "type": "number"
+              },
+              "unit": {
+                "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                "type": "string",
+                "enum": [
+                  "mW",
+                  "W",
+                  "VA"
+                ]
+              },
+              "location": {
+                "description": "The location of your sensor",
+                "type": "string",
+                "examples": [
+                  "Room 1",
+                  "Lab"
+                ]
+              },
+              "name": {
+                "description": "This field is an additional field to give your sensor a name. This can be useful if you have multiple sensors in the same location.",
+                "type": "string"
+              },
+              "description": {
+                "description": "An extra field that you can use to attach some additional information to this sensor instance",
+                "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently",
+                "type": "number"
+              }
+            },
+            "required": [
+              "value",
+              "unit",
+              "location"
+            ]
+          }
+        },
         "wind": {
           "description": "Your wind sensor",
           "type": "array",

--- a/15-draft.json
+++ b/15-draft.json
@@ -830,7 +830,6 @@
                 "description": "The unit of the sensor value.",
                 "type": "string",
                 "enum": [
-                  "mW",
                   "W",
                   "VA"
                 ]


### PR DESCRIPTION
EDIT: We have a solar panel near our space. So far, spaceapi only allowed for `power_consumption`, but `power_generation` was still missing.
This PR intends to change that.

An example can be found at: https://spaceapi.ccc-p.org/