### PR TITLE
Make location optional (Discussion: Extend SpaceAPI to associations without physical meeting locations)

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -27,7 +27,7 @@
       "type": "string"
     },
     "location": {
-      "description": "Position data such as a postal address or geographic coordinates",
+      "description": "Position data such as a postal address or geographic coordinates. May be omitted for spaces without a fixed physical location.",
       "type": "object",
       "properties": {
         "address": {
@@ -1444,7 +1444,6 @@
     "space",
     "logo",
     "url",
-    "location",
     "contact"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Root level:
 `location`:
 
 - [added] The `hint` field was added ([#102])
+- [changed] Make entire `location` field optional to enable the inclusion of groups without physical location ([#106])
 
 `sensors`:
 
@@ -105,3 +106,4 @@ Root level:
 [#98]: https://github.com/SpaceApi/schema/pull/98
 [#102]: https://github.com/SpaceApi/schema/pull/102
 [#105]: https://github.com/SpaceApi/schema/pull/105
+[#106]: https://github.com/SpaceApi/schema/pull/106


### PR DESCRIPTION
@SpaceApi/core The idea for this PR comes from a discussion at the CCC *Regiowochenende* 2023, and is supposed to serve as a starting point for further discussion.

Apart from hacker- and makerspaces, which have a (more or less) permanent, fixed location in the physical world, there are also other types of groups which cannot be properly represented by the current SpaceAPI schema. Concrete examples of such groups are:
- Regional umbrella associations consisting of multiple hacker- or makerspaces
- Supra-regional associations of people from spaces all over the world

One such regional umbrella association has recently created a dedicated SpaceAPI endpoint where they publish news and calendar feeds for events organized by the umbrella organization. Their endpoint currently contains a `location` to be schema compliant, but it doesn't point to a meaningful location. In addition, the endpoints of the individual spaces (which are part of the umbrella organization) have started adding the `ext_habitat` field to their API endpoints to signal that they are part of a larger association (which is something I'd rather see as an entry in `linked_spaces` instead).

Members of another supra-regional association have expressed that they would like to offer a SpaceAPI endpoint, so that their news and calendar feeds could be ingested by SpaceAPI aggregators such as spaceapi.ccc.de.

I'm not yet entirely happy with this PR (I don't think `hub` is the best term to use, and I'm not sure how many types of organizations we would want to distinguish), but I'd like to get the discussion started about whether we want to extend SpaceAPI to include associations without physical meeting locations.

CC @cyroxx