### PR TITLE
Add areas to location

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -66,6 +66,44 @@
             "Ring the doorbell marked with HACKSPACE",
             "Knock three times, say Shibboleet and follow the white rabbit"
           ]
+        },
+        "areas": {
+          "description": "A list of areas in your space. Must include at least 1 area if defined.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of this area",
+                "examples": [
+                  "Hackerspace",
+                  "Kitchen",
+                  "Workshop"
+                ]
+              },
+              "description": {
+                "type": "string",
+                "description": "A description of this area",
+                "examples": [
+                  "Our hackerspace area",
+                  "Woodworking machines and power tools"
+                ]
+              },
+              "square_meters": {
+                "type": "number",
+                "description": "The size of this area in square meters",
+                "examples": [
+                  23.23,
+                  42
+                ]
+              }
+            },
+            "required": [
+              "square_meters"
+            ]
+          },
+          "minItems": 1
         }
       },
       "required": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ Root level:
 
 `location`:
 
-- [added] The `hint` field was added ([#102])
 - [added] The `country_code` field was added ([#108])
+- [added] The `areas` field was added ([#107])
+- [added] The `hint` field was added ([#102])
 - [changed] Make entire `location` field optional to enable the inclusion of groups without physical location ([#106])
 
 `sensors`:
@@ -109,3 +110,4 @@ Root level:
 [#105]: https://github.com/SpaceApi/schema/pull/105
 [#106]: https://github.com/SpaceApi/schema/pull/106
 [#108]: https://github.com/SpaceApi/schema/pull/108
+[#107]: https://github.com/SpaceApi/schema/pull/107


### PR DESCRIPTION
This key can be used to specify a list of areas that make up your physical location. Each area has a required size (in square meters), and an optional name and description.

Replaces #71. (See discussion in that MR for context.)