### PR TITLE
Add country_code to location

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -50,6 +50,15 @@
             "Antarctica/Palmer"
           ]
         },
+        "country_code": {
+          "description": "Country code in ISO 3166 alpha-2 format",
+          "type": "string",
+          "examples": [
+            "CH",
+            "DE",
+            "UA"
+          ]
+        },
         "hint": {
           "description": "Information that can be used to describe how to access your space, if it is not trivial to find when standing at the address",
           "type": "string",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Root level:
 `location`:
 
 - [added] The `hint` field was added ([#102])
+- [added] The `country_code` field was added ([#108])
 - [changed] Make entire `location` field optional to enable the inclusion of groups without physical location ([#106])
 
 `sensors`:
@@ -107,3 +108,4 @@ Root level:
 [#102]: https://github.com/SpaceApi/schema/pull/102
 [#105]: https://github.com/SpaceApi/schema/pull/105
 [#106]: https://github.com/SpaceApi/schema/pull/106
+[#108]: https://github.com/SpaceApi/schema/pull/108


### PR DESCRIPTION
Add an ISO-3166 alpha-2 country code to the location object.

Note: One could argue that - since the `location` becomes optional with #106 - the country code can be used for umbrella organizations and spaces without fixed location as well and should be outside of the `location` key. On the other hand, the same thing county for the time zone, so I decided to stick with `location`.

Resolves #74.