### PR TITLE
Clean up units

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -414,11 +414,10 @@
                 "type": "number"
               },
               "unit": {
-                "description": "The unit of pressure used by your sensor<br>Note: The <code>hPA</code> unit is deprecated and should not be used anymore. Use the correct <code>hPa</code> unit instead.",
+                "description": "The unit of pressure used by your sensor",
                 "type": "string",
                 "enum": [
-                  "hPa",
-                  "hPA"
+                  "hPa"
                 ]
               },
               "location": {

--- a/15-draft.json
+++ b/15-draft.json
@@ -694,7 +694,7 @@
                 "type": "number"
               },
               "unit": {
-                "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                "description": "The humidity unit",
                 "type": "string",
                 "enum": [
                   "%"
@@ -787,7 +787,7 @@
                 "type": "number"
               },
               "unit": {
-                "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                "description": "The power unit",
                 "type": "string",
                 "enum": [
                   "W",
@@ -887,7 +887,7 @@
                         "type": "number"
                       },
                       "unit": {
-                        "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                        "description": "The wind speed unit",
                         "type": "string",
                         "enum": [
                           "m/s",
@@ -910,7 +910,7 @@
                         "type": "number"
                       },
                       "unit": {
-                        "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                        "description": "The gust speed unit",
                         "type": "string",
                         "enum": [
                           "m/s",
@@ -933,7 +933,7 @@
                         "type": "number"
                       },
                       "unit": {
-                        "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                        "description": "The direction unit",
                         "type": "string",
                         "enum": [
                           "°"
@@ -954,7 +954,7 @@
                         "type": "number"
                       },
                       "unit": {
-                        "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
+                        "description": "The elevation unit",
                         "type": "string",
                         "enum": [
                           "m"

--- a/15-draft.json
+++ b/15-draft.json
@@ -790,7 +790,6 @@
                 "description": "The unit of the sensor value. You should always define the unit though if the sensor is a flag of a boolean type then you can of course omit it.",
                 "type": "string",
                 "enum": [
-                  "mW",
                   "W",
                   "VA"
                 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Changes should start with one of the following tags:
 - `[changed]` for changes to the existing API
 - `[removed]` for keys that have been removed from the schema
 
+## v15
+
+`sensors`:
+
+- [removed] The deprecated unit `hPA` in `barometer.unit` was removed, use `hPa` instead
+
 ## v14
 
 Root level:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes should start with one of the following tags:
 `sensors`:
 
 - [removed] The deprecated unit `hPA` in `barometer.unit` was removed, use `hPa` instead
+- [removed] The redundant unit `mW` in `power_consumption.unit` was removed, use `W` instead
 
 ## v14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Changes should start with one of the following tags:
 
 `sensors`:
 
-- [removed] The deprecated unit `hPA` in `barometer.unit` was removed, use `hPa` instead
-- [removed] The redundant unit `mW` in `power_consumption.unit` was removed, use `W` instead
+- [removed] The deprecated unit `hPA` in `barometer.unit` was removed, use `hPa` instead ([#109])
+- [removed] The redundant unit `mW` in `power_consumption.unit` was removed, use `W` instead ([#109])
 
 ## v14
 
@@ -80,3 +80,4 @@ Root level:
 [#72]: https://github.com/SpaceApi/schema/pull/72
 [#77]: https://github.com/SpaceApi/schema/pull/77
 [#80]: https://github.com/SpaceApi/schema/pull/80
+[#109]: https://github.com/SpaceApi/schema/pull/109


### PR DESCRIPTION
- Remove deprecated hPA unit from barometer sensor
- Remove redundant mW unit from power_consumption sensor
- Clean up nonsensical unit descriptions

There are other redundant units, for example temperature in kelvin or fahrenheit (and many others), or wind speed in m/s vs km/h. However, I decided not to touch those for now.