### PR TITLE
chore: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/update-docker-image.yml
+++ b/.github/workflows/update-docker-image.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@v5
         with:

--- a/.github/workflows/validate-formatting.yml
+++ b/.github/workflows/validate-formatting.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         schema: [12, 13, 14, 15-draft]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Reformat JSON with jq
         run: jq . -M --indent 2 < ${{ matrix.schema }}.json > ${{ matrix.schema }}-formatted.json
       - name: Check for differences

--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         schema: [12, 13, 14, 15-draft]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install validator
         run: npm install ajv-cli@3.1.0
       - name: Download JSON meta-schema


### PR DESCRIPTION
All the Github Actions are complaing about Node 16 deprecation in actions/checkout@v2. This bumps them all to the most recent version v4.