### PR TITLE
Location: Make lat/lon optional, but add more validation logic

### DIFF
--- a/15-draft.json
+++ b/15-draft.json
@@ -106,10 +106,15 @@
           "minItems": 1
         }
       },
-      "required": [
-        "lat",
-        "lon"
-      ]
+      "minProperties": 1,
+      "dependentRequired": {
+        "lat": [
+          "lon"
+        ],
+        "lon": [
+          "lat"
+        ]
+      }
     },
     "spacefed": {
       "description": "A flag indicating if the hackerspace uses SpaceFED, a federated login scheme so that visiting hackers can use the space WiFi with their home space credentials.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Root level:
 - [added] The `areas` field was added ([#107])
 - [added] The `hint` field was added ([#102])
 - [changed] Make entire `location` field optional to enable the inclusion of groups without physical location ([#106])
+- [changed] If the `location` field is present, it requires at least 1 property ([#115])
+- [changed] Make the `lat`/`lon` fields optional, but if one of them is provided, then the other one must be provided too ([#115])
 
 `sensors`:
 
@@ -115,3 +117,4 @@ Root level:
 [#106]: https://github.com/SpaceApi/schema/pull/106
 [#108]: https://github.com/SpaceApi/schema/pull/108
 [#107]: https://github.com/SpaceApi/schema/pull/107
+[#115]: https://github.com/SpaceApi/schema/pull/115


### PR DESCRIPTION
This change makes the `lat` and `lon` fields optional (see discussion in #112), but adds some validation logic:

- The `location` fields needs at least one property
- If `lat` is specified, then `lon` is required as well (and vice versa)

This means that `"location": {},` is not valid (at least 1 property required), neither is `"location": {"lat": 1.23}` (both lat and lon) must be specified). But `"location": {"timezone": "Antarctica/Palmer"}` is valid.

Logic is based on the latest [JSON Schema validation draft](https://json-schema.org/draft/2020-12/json-schema-validation#name-validation-keywords-for-obj). I don't know whether there is significant support in tooling for these fields.

Fixes #112 