### PR TITLE
Add CO2 sensor

### DIFF
--- a/15.json
+++ b/15.json
@@ -417,6 +417,54 @@
             ]
           }
         },
+        "carbondioxide": {
+          "description": "CO2 sensor",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "value": {
+                "description": "The sensor value",
+                "type": "number"
+              },
+              "unit": {
+                "description": "The unit of the sensor value.",
+                "type": "string",
+                "enum": [
+                  "ppm",
+                  "vol%"
+                ]
+              },
+              "location": {
+                "description": "The location of your sensor",
+                "type": "string",
+                "examples": [
+                  "Outside",
+                  "Inside",
+                  "Ceiling",
+                  "Room 1"
+                ]
+              },
+              "name": {
+                "description": "This field is an additional field to give your sensor a name. This can be useful if you have multiple sensors in the same location.",
+                "type": "string"
+              },
+              "description": {
+                "description": "An extra field that you can use to attach some additional information to this sensor instance",
+                "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently",
+                "type": "number"
+              }
+            },
+            "required": [
+              "value",
+              "unit",
+              "location"
+            ]
+          }
+        },
         "door_locked": {
           "description": "Sensor type to indicate if a certain door is locked.",
           "type": "array",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Root level:
 `sensors`:
 
 - [added] The `power_generation` sensor was added ([#105])
+- [added] The `carbondioxide` sensor was added ([#116])
 - [added] The `lastchange` field was added to all sensors ([#97])
 - [removed] The deprecated unit `hPA` in `barometer.unit` was removed, use `hPa` instead ([#109])
 - [removed] The redundant unit `mW` in `power_consumption.unit` was removed, use `W` instead ([#109])


### PR DESCRIPTION
We recently deployed a CO2 sensor and noticed, that there is no sensor for it available within the spaceapi json schema. Therefore I propose to add an CO2/carbondioxide sensor to it :) I assumed, that it can be added to the v15 draft? I just copied the temperature sensor section and adjusted it to fit CO2.

As of now, I found three spaces, that already have CO2 sensor data published. Apparently, all three use different names for them:
- CCC Darmstadt: `co2`
- FabLab Nürnberg: `ext_co2`
- Nerdberg: `carbondioxide`

I just took `carbondioxide` but `co2` should be fine too.

/CC @poschi3