### PR TITLE
Added new contact field for Telegram chats

### DIFF
--- a/16-draft.json
+++ b/16-draft.json
@@ -258,6 +258,13 @@
                 "description": "Email address which can be base64 encoded.",
                 "type": "string"
               },
+              "telegram": {
+                "description": "Telegram channel link",
+                "type": "string",
+                "examples": [
+                  "https://t.me/example-space"
+                ]
+              },
               "twitter": {
                 "description": "Twitter username with leading <code>@</code>",
                 "type": "string",

--- a/16-draft.json
+++ b/16-draft.json
@@ -258,13 +258,6 @@
                 "description": "Email address which can be base64 encoded.",
                 "type": "string"
               },
-              "telegram": {
-                "description": "Telegram channel link",
-                "type": "string",
-                "examples": [
-                  "https://t.me/example-space"
-                ]
-              },
               "twitter": {
                 "description": "Twitter username with leading <code>@</code>",
                 "type": "string",
@@ -362,6 +355,13 @@
           "type": "string",
           "examples": [
             "mumble://mumble.example.org/spaceroom?version=1.2.0"
+          ]
+        },
+        "telegram": {
+          "description": "URL to Telegram channel",
+          "type": "string",
+          "examples": [
+            "https://t.me/example-channel"
           ]
         }
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Changes should start with one of the following tags:
 
 ## v16 (unreleased)
 
+`contact`:
+
+- [added] The `telegram` contact option was added ([#120])
+
 ## v15
 
 Root level:


### PR DESCRIPTION
Yes, some spaces use Telegram ;-). This adds a new field for Telegram chats.

Not sure if it's good to provide an URL to a Telegram channel that does not exist and could be registered by someone... Maybe the example should be removed?

Best,
Mänu