### PR TITLE
Use 16-draft as the version identifier of the next version

### DIFF
--- a/16-draft.json
+++ b/16-draft.json
@@ -11,7 +11,7 @@
         "type": "string"
       },
       "contains": {
-        "const": "16"
+        "const": "16-draft"
       }
     },
     "space": {


### PR DESCRIPTION
This allows to test the validator, while making sure that we do not have an outdated version of the spec in the validator library once the next version gets released.