### PR TITLE
Add 'telegram' contact field for keymasters

### DIFF
--- a/16-draft.json
+++ b/16-draft.json
@@ -282,6 +282,13 @@
                 "examples": [
                   "@user:example.org"
                 ]
+              },
+              "telegram": {
+                "description": "Telegram username with leading <code>@</code>",
+                "type": "string",
+                "examples": [
+                  "@user"
+                ]
               }
             }
           }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changes should start with one of the following tags:
 `contact`:
 
 - [added] The `telegram` contact option was added ([#120])
+- [added] The `telegram` contact option for keymasters was added ([#126])
 
 ## v15
 


### PR DESCRIPTION
After #120 was merged, it makes sense to add a way to contact the keymasters via Telegram as well.