### PR TITLE
Radiation sensors link

### DIFF
--- a/13.json
+++ b/13.json
@@ -389,7 +389,7 @@
           }
         },
         "radiation": {
-          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/gm-tubes-supported\" target=\"_blank\">resource</a>.",
+          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/technical/gm-tubes-supported\" target=\"_blank\">resource</a>.",
           "type": "object",
           "properties": {
             "alpha": {

--- a/14.json
+++ b/14.json
@@ -434,7 +434,7 @@
           }
         },
         "radiation": {
-          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/gm-tubes-supported\" target=\"_blank\">resource</a>.",
+          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/technical/gm-tubes-supported\" target=\"_blank\">resource</a>.",
           "type": "object",
           "properties": {
             "alpha": {

--- a/15.json
+++ b/15.json
@@ -550,7 +550,7 @@
           }
         },
         "radiation": {
-          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/gm-tubes-supported\" target=\"_blank\">resource</a>.",
+          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/technical/gm-tubes-supported\" target=\"_blank\">resource</a>.",
           "type": "object",
           "properties": {
             "alpha": {

--- a/16-draft.json
+++ b/16-draft.json
@@ -509,7 +509,7 @@
           }
         },
         "radiation": {
-          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/gm-tubes-supported\" target=\"_blank\">resource</a>.",
+          "description": "Compound radiation sensor. Check this <a rel=\"nofollow\" href=\"https://sites.google.com/site/diygeigercounter/technical/gm-tubes-supported\" target=\"_blank\">resource</a>.",
           "type": "object",
           "properties": {
             "alpha": {


### PR DESCRIPTION
While working on [Simple SpaceAPI](https://github.com/He4eT/simple-spaceapi),  
I noticed that the link in the "radiation sensors" section was outdated.  
I replaced it with a new one — hopefully it's the correct one.