### PR TITLE
Add `particulate_matter` sensor type

### DIFF
--- a/16-draft.json
+++ b/16-draft.json
@@ -1307,6 +1307,146 @@
             ]
           },
           "minItems": 1
+        },
+        "particulate_matter": {
+          "description": "Concentration of particulate matter in the air.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "properties": {
+                "type": "object",
+                "properties": {
+                  "PM10": {
+                    "description": "Concentration of particulate matter with a diameter of 10µm or less.",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value",
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "unit": {
+                        "description": "The measurement unit",
+                        "type": "string",
+                        "enum": [
+                          "µg/m³"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "unit"
+                    ]
+                  },
+                  "PM4.25": {
+                    "description": "Concentration of particulate matter with a diameter of 4.25µm or less.",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value",
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "unit": {
+                        "description": "The measurement unit",
+                        "type": "string",
+                        "enum": [
+                          "µg/m³"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "unit"
+                    ]
+                  },
+                  "PM2.5": {
+                    "description": "Concentration of particulate matter with a diameter of 2.5µm or less.",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value",
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "unit": {
+                        "description": "The measurement unit",
+                        "type": "string",
+                        "enum": [
+                          "µg/m³"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "unit"
+                    ]
+                  },
+                  "PM1": {
+                    "description": "Concentration of particulate matter with a diameter of 1µm or less.",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value",
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "unit": {
+                        "description": "The measurement unit",
+                        "type": "string",
+                        "enum": [
+                          "µg/m³"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "unit"
+                    ]
+                  },
+                  "PM0.3": {
+                    "description": "Concentration of particulate matter with a diameter of 0.3µm or less.",
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "description": "The measurement value",
+                        "type": "number",
+                        "minimum": 0
+                      },
+                      "unit": {
+                        "description": "The measurement unit",
+                        "type": "string",
+                        "enum": [
+                          "µg/m³"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "unit"
+                    ]
+                  }
+                }
+              },
+              "location": {
+                "description": "Location the measurement relates to, e.g. <samp>Hackerspace</samp>.",
+                "type": "string"
+              },
+              "description": {
+                "description": "An extra field that you can use to attach some additional information to this sensor instance",
+                "type": "string"
+              },
+              "lastchange": {
+                "description": "The Unix timestamp (in seconds) when the sensor value changed most recently",
+                "type": "number"
+              }
+            },
+            "required": [
+              "properties"
+            ]
+          },
+          "minItems": 1
         }
       }
     },

--- a/16-draft.json
+++ b/16-draft.json
@@ -1404,30 +1404,8 @@
                       "value",
                       "unit"
                     ]
-                  },
-                  "PM0.3": {
-                    "description": "Concentration of particulate matter with a diameter of 0.3µm or less.",
-                    "type": "object",
-                    "properties": {
-                      "value": {
-                        "description": "The measurement value",
-                        "type": "number",
-                        "minimum": 0
-                      },
-                      "unit": {
-                        "description": "The measurement unit",
-                        "type": "string",
-                        "enum": [
-                          "µg/m³"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "value",
-                      "unit"
-                    ]
                   }
-                }
+		}
               },
               "location": {
                 "description": "Location the measurement relates to, e.g. <samp>Hackerspace</samp>.",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changes should start with one of the following tags:
 - [added] The `telegram` contact option was added ([#120])
 - [added] The `telegram` contact option for keymasters was added ([#126])
 
+`sensors`:
+
+- [added] The `particulate_matter` sensor was added ([#131])
+
 ## v15
 
 Root level:
@@ -126,3 +130,4 @@ Root level:
 [#108]: https://github.com/SpaceApi/schema/pull/108
 [#107]: https://github.com/SpaceApi/schema/pull/107
 [#115]: https://github.com/SpaceApi/schema/pull/115
+[#131]: https://github.com/SpaceApi/schema/pull/131


### PR DESCRIPTION
This PR adds support for the `particulate_matter` sensor type as proposed in #129.

@mweinelt I would also ask you to provide feedback as well since you requested this feature in the first place.